### PR TITLE
Add TypeScript type declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "repository": "https://github.com/SafetyCulture/bcp47.git",
   "scripts": {
     "test": "NODE_ENV=test LOG_LEVEL=fatal mocha --recursive --compilers js:babel-register --reporter $npm_package_config_reporter -s 120 $npm_package_config_test_opts",
@@ -27,8 +28,9 @@
     "audit": "nsp check",
     "check": "npm run audit && npm run deps && npm outdated --depth 0",
     "clean": "rm -rf node_modules/ && rm -rf coverage",
-    "prepublish": "npm run compile && npm test",
-    "pretest": "npm run lint"
+    "prepublish": "npm run compile && npm run copy-typescript && npm test",
+    "pretest": "npm run lint",
+    "copy-typescript": "ncp src/index.d.ts dist/index.d.ts"
   },
   "author": "(C) 2017 SafetyCulture Pty Ltd",
   "config": {
@@ -52,6 +54,7 @@
     "istanbul": "^1.0.0-alpha.2",
     "lodash": "^4.15.0",
     "mocha": "^2.5.3",
+    "ncp": "^2.0.0",
     "nock": "^8.0.0",
     "nsp": "^2.5.0"
   },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,4 @@
+export const pattern: RegExp;
+
+// Parameter should be a string, but anything can be passed
+export function validate(locale: string | any): boolean;  


### PR DESCRIPTION
This is a contribution I'm offering to your package. Would you like it?

This provides a TypeScript declaration file so bcp47-validate can be used nicely with TypeScript.  (I could add it to the general https://github.com/DefinitelyTyped/DefinitelyTyped repo, but it seems nicer if it comes pre-bundled with your package).

Potentially controversially, I added "ncp" as a dev dependency.  This is just to copy the index.d.ts file over to the dist folder in a platform neutral way.

I considered, briefly, converting your index.js file to index.ts, but it seemed like a much too heavy-handed contribution. 

Feedback welcomed!